### PR TITLE
fix(ci): drop unused elsa dev dependency breaking emacs 26-27 builds

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,5 +6,4 @@
 (package-file "ddskk-posframe.el")
 
 (development
- (depends-on "elsa")
  (depends-on "buttercup"))


### PR DESCRIPTION
## Root cause

The `Main workflow` CI fails on every pinned Emacs version (26.1, 26.2, 26.3, 27.1). All setup steps (checkout, setup-python, setup-emacs, setup-cask) succeed; the failure is in the `make test` step.

`make test` first runs `cask install`. The `Cask` file declares `elsa` as a development dependency. The latest `elsa` release on MELPA now requires `emacs-29.1`, so the install aborts:

```
Missing dependency: "Package 'emacs-29.1' is unavailable"
  - Installing [ 6/21] elsa (latest)... downloading
make: *** [Makefile:61: .cask] Error 255
```

This is why only the pinned matrix fails while the `snapshot` job (Emacs 30, marked `allow_failure`) installs `elsa` fine.

## Fix

`elsa` is not referenced anywhere outside `Cask` — the Makefile `test` target only runs `buttercup`, and there is no lint step that uses it. Removing the unused `elsa` dev dependency restores `cask install` on the Emacs 26.1–27.1 matrix.

No `Package-Requires` change is needed: the matrix still covers Emacs 26.1+, consistent with the `(emacs "26.1")` header and the README.

## Test plan

- [ ] `Main workflow` passes for Emacs 26.1, 26.2, 26.3, 27.1
- [ ] `snapshot` job remains green


---
_Generated by [Claude Code](https://claude.ai/code/session_01HcPQhBm5iZSeTkNzQw8oM1)_