### PR TITLE
chore: update dependencies to latest versions

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,4 +6,4 @@
 (package-file "ddskk-posframe.el")
 
 (development
- (depends-on "buttercup"))
+ (depends-on "buttercup" "1.40"))

--- a/ddskk-posframe.el
+++ b/ddskk-posframe.el
@@ -7,7 +7,7 @@
 ;; Keywords: tooltip convenience posframe
 ;; Version: 1.0.9
 ;; URL: https://github.com/conao3/ddskk-posframe.el
-;; Package-Requires: ((emacs "26.1") (posframe "0.4.3") (ddskk "16.2.50"))
+;; Package-Requires: ((emacs "26.1") (posframe "1.5.1") (ddskk "17.2"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the Affero GNU General Public License as


### PR DESCRIPTION
## Summary

Modernizes the package dependencies to their latest stable versions (MELPA Stable).

| Dependency | Before | After | Note |
|---|---|---|---|
| `posframe` | `0.4.3` | `1.5.1` | major bump (0.x → 1.x) |
| `ddskk` | `16.2.50` | `17.2` | major bump (16 → 17) |
| `buttercup` (dev) | unpinned | `1.40` | now pinned in `Cask` |
| `emacs` | `26.1` | `26.1` | unchanged — see deferred note |

## Deferred / notes

- **`emacs` minimum kept at `26.1`**: the CI matrix (`.github/workflows/test.yml`) tests Emacs `26.1`–`27.1`. Raising the minimum would break those matrix jobs, so this bump is intentionally deferred to keep CI green.
- **No lockfile**: this project has no dependency lockfile. Cask resolves packages at install time and `.cask/` is gitignored, so there is nothing to regenerate.

## Test plan

- [x] `cask install` resolves cleanly to `posframe 1.5.1`, `ddskk 17.2`, `buttercup 1.40`
- [x] `make test` — byte-compilation succeeds with no errors and the buttercup suite passes (1 spec, 0 failed)


---
_Generated by [Claude Code](https://claude.ai/code/session_0133A7AjUP8S8j4Eew62bX5y)_